### PR TITLE
support base 4.8, ignore cabal sandboxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /dist/
+/.cabal-sandbox/
+cabal.sandbox.config

--- a/freetype-simple.cabal
+++ b/freetype-simple.cabal
@@ -24,7 +24,7 @@ library
   exposed-modules:     Graphics.Rendering.FreeType.Simple
   -- other-modules:       
   other-extensions:    RecordWildCards
-  build-depends:       base >=4.7 && <4.8, boundingboxes >=0.2 && <0.3, bytestring >=0.10 && <0.11, linear >=1.15 && <1.20, freetype2 ==0.1.*
+  build-depends:       base >=4.7 && <4.9, boundingboxes >=0.2 && <0.3, bytestring >=0.10 && <0.11, linear >=1.20 && <1.21, freetype2 ==0.1.*
   -- hs-source-dirs:      
   --build-tools:         
   default-language:    Haskell2010


### PR DESCRIPTION
Please note that supporting base 4.8 also requires at least linear 1.20 because of conflicting orphan instances.
